### PR TITLE
Fix map entry deletion

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -19,7 +19,7 @@ func main() {
 		mutex.Lock()
 		m[cnt] = newBuffer
 		if cnt >= max {
-			m[cnt-max] = nil
+			delete(m, cnt-max)
 		}
 		cnt = cnt + 1
 		mutex.Unlock()


### PR DESCRIPTION
Affecting nil to a map entry doesn't delete the entry, and the map grows indefinitely. Use the delete statement instead.
