### PR TITLE
Call handler directly (bypass the HTTP router)

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -25,6 +25,5 @@ func main() {
 		mutex.Unlock()
 		io.WriteString(w, "OK")
 	}
-	http.HandleFunc("/", handler)
-	http.ListenAndServe(":8080", nil)
+	http.ListenAndServe(":8080", http.HandlerFunc(handler))
 }


### PR DESCRIPTION
Let's make the Go version closer to Reason and Node versions which don't use a router.
